### PR TITLE
filter_by_description: use SQL objects

### DIFF
--- a/notebooks/TDMQ_API_Experiments.ipynb
+++ b/notebooks/TDMQ_API_Experiments.ipynb
@@ -213,6 +213,7 @@
       "text/plain": [
        "[{'code': '0fd67c67-c9be-45c6-9719-4c4eada4becc',\n",
        "  'geometry': {'coordinates': [9.221, 30.0], 'type': 'Point'},\n",
+       "  'name': 'test',\n",
        "  'nodecode': '0fd67ccc-c9be-45c6-9719-4c4eada4beaa',\n",
        "  'stypecode': '0fd67c67-c9be-45c6-9719-4c4eada4be65'},\n",
        " {'code': '0fd67c67-c9be-45c6-9719-4c4eada4beff',\n",
@@ -256,6 +257,7 @@
       "text/plain": [
        "{'code': '0fd67c67-c9be-45c6-9719-4c4eada4becc',\n",
        " 'geometry': {'coordinates': [9.221, 30.0], 'type': 'Point'},\n",
+       " 'name': 'test',\n",
        " 'nodecode': '0fd67ccc-c9be-45c6-9719-4c4eada4beaa',\n",
        " 'stypecode': '0fd67c67-c9be-45c6-9719-4c4eada4be65'}"
       ]
@@ -274,12 +276,44 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Sensors by type"
+    "### Sensors by attribute"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'code': '0fd67c67-c9be-45c6-9719-4c4eada4becc',\n",
+       "  'geometry': {'coordinates': [9.221, 30.0], 'type': 'Point'},\n",
+       "  'name': 'test',\n",
+       "  'nodecode': '0fd67ccc-c9be-45c6-9719-4c4eada4beaa',\n",
+       "  'stypecode': '0fd67c67-c9be-45c6-9719-4c4eada4be65'}]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "args = {\"name\": \"test\"}\n",
+    "requests.get(f'{BASE_URL}/sensors', params=args).json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Sensors by type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -311,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -327,7 +361,7 @@
        "  'stypecode': '0fd67c67-c9be-45c6-9719-4c4eada4bebe'}]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -343,7 +377,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -352,7 +386,7 @@
        "[]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -375,7 +409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -386,7 +420,7 @@
        " 'timedelta': [0.0, 5.0, 10.0, 15.0, 20.0, 25.0]}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -401,7 +435,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -412,7 +446,7 @@
        " 'timedelta': [0.0, 10.0, 20.0]}"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -429,7 +463,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -440,7 +474,7 @@
        " 'timedelta': [0.0, 4.8, 9.9, 15.0, 19.8, 24.9]}"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -472,7 +506,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/tdmq/api.py
+++ b/tdmq/api.py
@@ -122,8 +122,7 @@ def add_routes(app):
         :query type: consider only sensors of this type (filter by stypecode)
         :query {attribute}: select sensors whose description has the
             specified value(s) for the chosen attribute
-            (top-level JSON key, e.g., name=SensorName;
-            controlledProperty=humidity,temperature)
+            (top-level JSON key, e.g., name=SensorName)
 
         :status 200: no error
         :returns: list of sensors

--- a/tdmq/query_builder.py
+++ b/tdmq/query_builder.py
@@ -15,12 +15,12 @@ def filter_by_description(table_name, args):
     """\
     E.g., dict(brandName="Acme", controlledProperty="humidity,temperature")
     """
-    query = "".join([
-        "SELECT description FROM %s WHERE" % table_name,
-        " AND ".join(
-            "(description->%s @> %s::jsonb)" for _ in args
-        ),
-    ])
+    qstart = sql.SQL("SELECT description FROM {} WHERE").format(
+        sql.Identifier(table_name))
+    query = qstart + sql.SQL(" AND ").join(
+        sql.SQL("(description->{} @> {}::jsonb)").format(
+            sql.Placeholder(), sql.Placeholder())
+        for _ in args)
     data = []
     for k, v in args.items():
         data.append(k)


### PR DESCRIPTION
In `filter_by_description` the table name is now variable, so we need [SQL string composition](http://initd.org/psycopg/docs/sql.html#module-psycopg2.sql).

I have also added a filter-sensor-by-name example to the notebook and fixed the API docs.